### PR TITLE
Ensure log directory before initializing logger

### DIFF
--- a/progetti.3/lab2/include/log.h
+++ b/progetti.3/lab2/include/log.h
@@ -2,7 +2,9 @@
 #define LOG_H
 
 /*  log_init() va chiamata una sola volta all’avvio del server.
- *  Ritorna 0 se il file è stato aperto, −1 su errore.           */
+ *  Il percorso fornito deve avere già la directory di destinazione
+ *  già esistente (la funzione non la crea). Ritorna 0 se il file è
+ *  stato aperto, −1 su errore.                                     */
 int  log_init(const char *filepath);
 
 /*  log_event() funziona come printf(): accetta una stringa di

--- a/progetti.3/lab2/src/server.c
+++ b/progetti.3/lab2/src/server.c
@@ -4,6 +4,8 @@
 #include <string.h>
 #include <signal.h>
 #include <pthread.h>
+#include <sys/stat.h>
+#include <errno.h>
 
 #include "models.h"
 #include "parse_env.h"
@@ -47,6 +49,10 @@ int main(void) {
     }
 
     /* 3) Logger */
+    if (mkdir("logs", 0755) == -1 && errno != EEXIST) {
+        perror("mkdir logs");
+        return 1;
+    }
     if (log_init("logs/server.log") != 0) {
         perror("log_init");
         return 1;


### PR DESCRIPTION
## Summary
- create `logs` directory in `server.c` before initializing the logger
- document that `log_init` expects an existing directory

## Testing
- `make test-utils`
- `make test-parsers`


------
https://chatgpt.com/codex/tasks/task_e_6863e68e2d3c83218ff0e4e265caaff2