### PR TITLE
Add unknown rescuer handling

### DIFF
--- a/progetti.3/lab2/Makefile
+++ b/progetti.3/lab2/Makefile
@@ -91,8 +91,9 @@ test-utils: $(BIN_TEST_UTILS)
 # Test parsers modules
 BIN_TEST_PARSERS := $(BIN_DIR)/test_parsers
 $(BIN_TEST_PARSERS): tests/test_parsers.c \
-	src/parse_rescuers.c include/parse_rescuers.h \
-	src/parse_emergency_types.c include/parse_emergency_types.h
+        src/parse_rescuers.c include/parse_rescuers.h \
+        src/parse_emergency_types.c include/parse_emergency_types.h \
+        src/log.c include/log.h
 	@mkdir -p $(BIN_DIR)
 		$(CC) $(CFLAGS) -Iinclude $^ -o $@
 		chmod +x $@

--- a/progetti.3/lab2/tests/test_parsers.c
+++ b/progetti.3/lab2/tests/test_parsers.c
@@ -28,6 +28,17 @@ int main(void) {
     assert(nel == 1);
     assert(strcmp(el[0].name,"Fire")==0 && el[0].priority==2 && el[0].n_required==1);
     free(el);
+
+    // Unknown rescuer type should be logged and the line skipped
+    f = fopen("tests/_et.txt","w");
+    fprintf(f,"[Crash] [1] Foo:1,3;\n");
+    fclose(f);
+
+    el = NULL;
+    nel = 0;
+    assert(parse_emergency_types_file("tests/_et.txt", rl, nrl, &el, &nel) == 0);
+    assert(nel == 0);
+    free(el);
     free(rl);
 
     printf("[test_parsers] all tests passed\n");


### PR DESCRIPTION
## Summary
- log an error if parse_emergency_types_file finds an unknown rescuer
- skip emergency type line on unknown rescuer
- update parser tests for unknown rescuer lines
- link log module when building parser tests

## Testing
- `make test-parsers`
- `make test-utils`


------
https://chatgpt.com/codex/tasks/task_e_68646d0e91bc8321bdb8d6c9ba346957