### PR TITLE
Fix server build on Ubuntu 24.04

### DIFF
--- a/progetti.3/lab2/Makefile
+++ b/progetti.3/lab2/Makefile
@@ -68,7 +68,7 @@ $(BIN_SERVER): \
         include/queue.h \
         include/scheduler.h
 	@mkdir -p $(BIN_DIR)
-	$(CC) $(CFLAGS) -Iinclude $(filter %.c,$^) -o $@
+	$(CC) $(CFLAGS) -Iinclude $(filter %.c,$^) -o $@ -lrt
 
 .PHONY: client server
 client: $(BIN_CLIENT)


### PR DESCRIPTION
## Summary
- link the server with `-lrt` so mq functions resolve

## Testing
- `make server`
- `make test-utils`
- `make test-parsers`


------
https://chatgpt.com/codex/tasks/task_e_686471acbd1c83218745411bf02446b8