### PR TITLE
Fix trim when string empty and add test

### DIFF
--- a/progetti.3/lab2/Makefile
+++ b/progetti.3/lab2/Makefile
@@ -102,3 +102,13 @@ $(BIN_TEST_PARSERS): tests/test_parsers.c \
 test-parsers: $(BIN_TEST_PARSERS)
 	./$(BIN_TEST_PARSERS)
 
+# Test parse_env module
+BIN_TEST_PARSE_ENV := $(BIN_DIR)/test_parse_env
+$(BIN_TEST_PARSE_ENV): tests/test_parse_env.c src/parse_env.c include/parse_env.h
+	@mkdir -p $(BIN_DIR)
+	$(CC) $(CFLAGS) -Iinclude $^ -o $@
+
+.PHONY: test-parse-env
+test-parse-env: $(BIN_TEST_PARSE_ENV)
+	./$(BIN_TEST_PARSE_ENV)
+

--- a/progetti.3/lab2/src/parse_env.c
+++ b/progetti.3/lab2/src/parse_env.c
@@ -9,7 +9,9 @@ static void trim(char *s) {
     char *p = s;
     while (isspace((unsigned char)*p)) p++;
     memmove(s, p, strlen(p)+1);
-    for (char *e = s + strlen(s) - 1; e >= s && isspace((unsigned char)*e); --e)
+    size_t len = strlen(s);
+    if (len == 0) return;
+    for (char *e = s + len - 1; e >= s && isspace((unsigned char)*e); --e)
         *e = '\0';
 }
 

--- a/progetti.3/lab2/tests/test_parse_env.c
+++ b/progetti.3/lab2/tests/test_parse_env.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "parse_env.h"
+
+int main(void) {
+    FILE *f = fopen("tests/_env.conf", "w");
+    fprintf(f, "\nqueue=/tmpq\nwidth=5\nheight=7\n");
+    fclose(f);
+
+    env_config_t cfg;
+    assert(parse_env_file("tests/_env.conf", &cfg) == 0);
+    assert(strcmp(cfg.queue_name, "/tmpq") == 0);
+    assert(cfg.width == 5);
+    assert(cfg.height == 7);
+
+    printf("[test_parse_env] all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- handle empty strings in `trim` helper
- test empty line parsing through `parse_env_file`
- wire new unit test in Makefile

## Testing
- `make test-utils`
- `make test-parsers`
- `make test-parse-env`


------
https://chatgpt.com/codex/tasks/task_e_686472d9a35c8321be84c47514dbe766