### PR TITLE
Validate emergency rescuer names

### DIFF
--- a/progetti.3/lab2/src/parse_emergency_types.c
+++ b/progetti.3/lab2/src/parse_emergency_types.c
@@ -28,7 +28,9 @@ int parse_emergency_types_file(const char *path,
     char line[256];
     char name[32];
     int priority;
+    int line_no = 0;
     while (fgets(line, sizeof line, fp)) {
+        line_no++;
         char rest[200];
         if (sscanf(line, "[%31[^]]] [%d] %199[^\n]", name, &priority, rest) != 3)
             continue;
@@ -56,8 +58,8 @@ int parse_emergency_types_file(const char *path,
                 break;
             }
             int ridx = rescuer_index_by_name(rname, rlist, n_rlist);
-            if (ridx == -1) {
-                log_event("Unknown rescuer type '%s'", rname);
+            if (ridx < 0) {
+                log_event("FILE_PARSING: unknown rescuer type '%s' on line %d", rname, line_no);
                 valid_line = 0;
                 break;
             }

--- a/progetti.3/lab2/tests/test_parsers.c
+++ b/progetti.3/lab2/tests/test_parsers.c
@@ -39,6 +39,18 @@ int main(void) {
     assert(parse_emergency_types_file("tests/_et.txt", rl, nrl, &el, &nel) == 0);
     assert(nel == 0);
     free(el);
+
+    // Mixed valid and unknown rescuer names in the same line
+    f = fopen("tests/_et.txt","w");
+    fprintf(f,"[Mixed] [1] Amb:1,5; Foo:2,3;\n");
+    fclose(f);
+
+    el = NULL;
+    nel = 0;
+    assert(parse_emergency_types_file("tests/_et.txt", rl, nrl, &el, &nel) == 0);
+    assert(nel == 0);
+    free(el);
+
     free(rl);
 
     printf("[test_parsers] all tests passed\n");


### PR DESCRIPTION
## Summary
- detect invalid rescuer names when parsing emergency types
- add tests for mixed valid/invalid rescuer types

## Testing
- `make test-parsers`
- `make test-utils`
- `make test-parse-env`

------
https://chatgpt.com/codex/tasks/task_e_6864e351ff88832185b9dbda040307cf