### PR TITLE
Relocate log directory creation

### DIFF
--- a/progetti.3/lab2/src/scheduler.c
+++ b/progetti.3/lab2/src/scheduler.c
@@ -17,7 +17,8 @@
 /* After this many seconds a priority 0 emergency becomes priority 1 */
 #define AGING_THRESHOLD 60
 
-// Globals defined in server.c
+// Globals defined in server.c. The scheduler assumes the logs directory
+// already exists and is created by the server before threads start.
 extern rescuer_type_t   *rescuer_list;
 extern int               n_rescuers;
 extern emergency_type_t *etype_list;
@@ -85,10 +86,6 @@ static void *scheduler_loop(void *arg) {
         }
 
         // 3) Assign or timeout
-        if (mkdir("logs", 0755) == -1 && errno != EEXIST) {
-            perror("mkdir logs");
-            return 1;
-        }
         if (can_assign) {
             for (int j = 0; j < et->n_required; j++) {
                 rescuer_dt_t *dt = used[j];


### PR DESCRIPTION
## Summary
- create the log directory only once in `server.c`
- remove directory creation from the scheduler loop
- document that the scheduler assumes the directory already exists

## Testing
- `make test-utils`
- `make test-parsers`
- `make test-parse-env`


------
https://chatgpt.com/codex/tasks/task_e_6864e488acb88321ada852fa87cb0f10