### PR TITLE
Fix missing stdio include

### DIFF
--- a/progetti.3/lab2/src/scheduler.c
+++ b/progetti.3/lab2/src/scheduler.c
@@ -1,5 +1,6 @@
 #include <pthread.h>
 #include <signal.h>
+#include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Summary
- include `<stdio.h>` in `scheduler.c` to declare `perror`

## Testing
- `make server`

------
https://chatgpt.com/codex/tasks/task_e_6864e5ab14c48321a9cd85ee89167061