### PR TITLE
Fix client request type string termination

### DIFF
--- a/progetti.3/lab2/src/client.c
+++ b/progetti.3/lab2/src/client.c
@@ -22,6 +22,7 @@ int main(int argc, char *argv[]) {
         .timestamp = time(NULL)
     };
     strncpy(req.type, argv[3], sizeof(req.type)-1);
+    req.type[sizeof(req.type)-1] = '\0';
 
     mqd_t mq = mq_open(qname, O_WRONLY | O_CREAT, 0660, NULL);
     CHECK(mq);


### PR DESCRIPTION
## Summary
- ensure emergency type strings are null-terminated after copying
- rebuild client

## Testing
- `make client`

------
https://chatgpt.com/codex/tasks/task_e_6864e65d9278832180bb8bbb24bb5002