### PR TITLE
Improve digital twin synchronization

### DIFF
--- a/progetti.3/lab2/include/models.h
+++ b/progetti.3/lab2/include/models.h
@@ -2,11 +2,13 @@
 #define MODELS_H
 
 /* --------------- soccorritore ---------------- */
+#include <stdatomic.h>
+
 typedef struct {
-    char name[32];
-    int  number;
-    int  speed;
-    int  x, y;
+    char       name[32];
+    atomic_int number;
+    int        speed;
+    int        x, y;
 } rescuer_type_t;
 
 /* --------------- tipo di emergenza ------------ */


### PR DESCRIPTION
## Summary
- guard rescuer data with `atomic_int`
- lock each twin while scanning for idle or preemptible ones
- use atomic increments/decrements when updating the available count

## Testing
- `make test-utils test-parsers test-parse-env test-deadlock`
- `make server`

------
https://chatgpt.com/codex/tasks/task_e_6864f865ef608321addb290341f41a54