### PR TITLE
Add emergency status tracking

### DIFF
--- a/progetti.3/lab2/include/models.h
+++ b/progetti.3/lab2/include/models.h
@@ -20,6 +20,15 @@ typedef struct {
     int  time_to_manage;
 } emergency_type_t;
 
+typedef enum {
+    EM_STATUS_WAITING,
+    EM_STATUS_ASSIGNED,
+    EM_STATUS_IN_PROGRESS,
+    EM_STATUS_COMPLETED,
+    EM_STATUS_TIMEOUT,
+    EM_STATUS_CANCELED
+} emergency_status_t;
+
 /* --------------- emergenza attiva ------------- */
 typedef struct {
     int  id;
@@ -27,6 +36,7 @@ typedef struct {
     int  x, y;
     int  priority;
     long creation_time;
+    emergency_status_t status;
 } emergency_t;
 
 /* --------------- config dell’ambiente --------- */

--- a/progetti.3/lab2/include/scheduler.h
+++ b/progetti.3/lab2/include/scheduler.h
@@ -14,4 +14,10 @@ void scheduler_debug_add_paused(emergency_request_t req);
 int  scheduler_debug_get_paused_count(void);
 emergency_request_t scheduler_debug_get_paused(int idx);
 
+/* Emergency table utilities */
+void scheduler_add_emergency(const emergency_request_t *req);
+int  scheduler_set_emergency_status(int id, emergency_status_t st);
+int  scheduler_debug_get_emergency_count(void);
+emergency_t scheduler_debug_get_emergency(int idx);
+
 #endif /* SCHEDULER_H */

--- a/progetti.3/lab2/src/digital_twin.c
+++ b/progetti.3/lab2/src/digital_twin.c
@@ -1,6 +1,7 @@
 #include "digital_twin.h"
 #include "log.h"
 #include "utils.h"
+#include "scheduler.h"
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -43,7 +44,9 @@ static void *twin_loop(void *arg)
         int mtime = dt->manage_time;
         int eid = dt->emergency_id;
         dt->status = EN_ROUTE_TO_SCENE;
+        scheduler_set_emergency_status(eid, EM_STATUS_IN_PROGRESS);
         log_event("RESCUER_STATUS id=%d type=%s status=EN_ROUTE_TO_SCENE", dt->id, dt->type->name);
+        log_event("EMERGENCY_STATUS id=%d status=IN_PROGRESS", eid);
         pthread_mutex_unlock(&dt->mtx);
 
         double ttrav = travel_time_secs(dt->type, dt->x, dt->y, dx, dy);
@@ -84,6 +87,7 @@ static void *twin_loop(void *arg)
         dt->assigned = 0;
         atomic_fetch_add(&dt->type->number, 1);
         log_event("RESCUER_STATUS id=%d type=%s status=IDLE", dt->id, dt->type->name);
+        scheduler_set_emergency_status(eid, EM_STATUS_COMPLETED);
         log_event("EMERGENCY_STATUS id=%d status=COMPLETED", eid);
         pthread_mutex_unlock(&dt->mtx);
     }


### PR DESCRIPTION
## Summary
- add emergency status enumeration and field to `emergency_t`
- expose scheduler helpers for maintaining a table of active emergencies
- log status transitions for each emergency
- update digital twin to mark emergencies in progress and completed

## Testing
- `make test-utils`
- `make test-parsers`
- `make test-parse-env`
- `make test-deadlock`

------
https://chatgpt.com/codex/tasks/task_e_68650391d3308321a33c988d1c416079