### PR TITLE
Add scheduler integration tests

### DIFF
--- a/progetti.3/lab2/Makefile
+++ b/progetti.3/lab2/Makefile
@@ -122,3 +122,14 @@ $(BIN_TEST_DEADLOCK): tests/test_deadlock.c src/scheduler.c src/log.c include/sc
 test-deadlock: $(BIN_TEST_DEADLOCK)
 	./$(BIN_TEST_DEADLOCK)
 
+# Scheduler integration test
+BIN_TEST_SCHEDULER := $(BIN_DIR)/test_scheduler
+$(BIN_TEST_SCHEDULER): tests/test_scheduler.c \
+    src/scheduler.c src/queue.c src/log.c \
+    include/scheduler.h include/queue.h include/log.h include/models.h
+	@mkdir -p $(BIN_DIR)
+	$(CC) $(CFLAGS) -Iinclude $^ -o $@
+
+.PHONY: test-scheduler
+test-scheduler: $(BIN_TEST_SCHEDULER)
+	./$(BIN_TEST_SCHEDULER)

--- a/progetti.3/lab2/tests/test_scheduler.c
+++ b/progetti.3/lab2/tests/test_scheduler.c
@@ -1,0 +1,138 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include "scheduler.h"
+#include "digital_twin.h"
+#include "queue.h"
+#include <unistd.h>
+
+/* Globals required by scheduler.c */
+rescuer_type_t   *rescuer_list = NULL;
+int               n_rescuers   = 0;
+emergency_type_t *etype_list   = NULL;
+int               n_etypes     = 0;
+rescuer_dt_t     *dt_list      = NULL;
+int               dt_count     = 0;
+int               env_width    = 0;
+int               env_height   = 0;
+
+/* Stub digital twin data */
+static rescuer_dt_t dt_stub;
+static int assign_count = 0;
+static emergency_request_t last_assigned;
+
+rescuer_dt_t *digital_twin_find_idle(rescuer_dt_t *l,int n,rescuer_type_t *t){
+    if (n > 0 && l[0].assigned == 0 && l[0].type == t)
+        return &l[0];
+    return NULL;
+}
+
+rescuer_dt_t *digital_twin_find_preemptible(rescuer_dt_t *l,int n,rescuer_type_t *t,int p){
+    return NULL; /* not used */
+}
+
+int digital_twin_assign(rescuer_dt_t *dt,int id,const char *type,int pr,int x,int y,int tman){
+    dt->assigned = 1;
+    assign_count++;
+    last_assigned.id = id;
+    strncpy(last_assigned.type, type, sizeof(last_assigned.type)-1);
+    last_assigned.type[sizeof(last_assigned.type)-1] = '\0';
+    last_assigned.priority = pr;
+    last_assigned.x = x;
+    last_assigned.y = y;
+    return 0;
+}
+
+int digital_twin_preempt(rescuer_dt_t *dt,const emergency_request_t *r,int m,emergency_request_t *o){
+    return 0;
+}
+
+int main(void){
+    /* Setup single rescuer and emergency type */
+    static rescuer_type_t rescuer;
+    strcpy(rescuer.name, "Amb");
+    rescuer.number = 1;
+    rescuer.speed = 5;
+    rescuer.x = 0; rescuer.y = 0;
+    rescuer_list = &rescuer;
+    n_rescuers = 1;
+
+    static emergency_type_t etype;
+    strcpy(etype.name, "Fire");
+    etype.priority = 2;
+    etype.required_units[0] = 0;
+    etype.n_required = 1;
+    etype.time_to_manage = 5;
+    etype_list = &etype;
+    n_etypes = 1;
+
+    dt_stub.type = &rescuer;
+    dt_stub.assigned = 0;
+    dt_list = &dt_stub;
+    dt_count = 1;
+
+    env_width = 5;
+    env_height = 5;
+
+    bqueue_t q;
+    assert(bqueue_init(&q, 10) == 0);
+    assert(scheduler_start(&q) == 0);
+
+    long now = time(NULL);
+
+    /* 1) valid assignment */
+    emergency_request_t r1 = {1, "Fire", 1,1, 2, now};
+    bqueue_push(&q, r1);
+    sleep(1);
+    assert(assign_count == 1);
+    assert(last_assigned.id == 1);
+    assert(scheduler_debug_get_emergency_count() == 1);
+    emergency_t e1 = scheduler_debug_get_emergency(0);
+    assert(e1.status == EM_STATUS_ASSIGNED);
+
+    /* 2) invalid coordinates */
+    emergency_request_t r2 = {2, "Fire", -1,0, 2, now};
+    bqueue_push(&q, r2);
+    sleep(1);
+    assert(assign_count == 1); /* unchanged */
+    assert(scheduler_debug_get_emergency_count() == 1);
+
+    /* 3) invalid timestamp */
+    emergency_request_t r3 = {3, "Fire", 2,2, 2, now + 3600};
+    bqueue_push(&q, r3);
+    sleep(1);
+    assert(assign_count == 1);
+    assert(scheduler_debug_get_emergency_count() == 1);
+
+    /* 4) resource shortage -> timeout */
+    dt_stub.assigned = 1; /* no idle rescuers */
+    emergency_request_t r4 = {4, "Fire", 1,1, 2, now};
+    bqueue_push(&q, r4);
+    sleep(1);
+    assert(scheduler_debug_get_emergency_count() == 2);
+    emergency_t e2 = scheduler_debug_get_emergency(1);
+    assert(e2.status == EM_STATUS_TIMEOUT);
+
+    /* 5) aging priority 0 -> 1 */
+    dt_stub.assigned = 0; /* rescuer free */
+    emergency_request_t r5 = {5, "Fire", 2,2, 0, now - 70};
+    bqueue_push(&q, r5);
+    sleep(1);
+    assert(assign_count == 2);
+    assert(last_assigned.id == 5);
+    assert(last_assigned.priority == 1); /* aged */
+    assert(scheduler_debug_get_emergency_count() == 3);
+    emergency_t e3 = scheduler_debug_get_emergency(2);
+    assert(e3.status == EM_STATUS_ASSIGNED);
+
+    /* push dummy event so scheduler thread can exit cleanly */
+    emergency_request_t done = {99, "Fire", 0,0, 2, now};
+    bqueue_push(&q, done);
+
+    scheduler_stop();
+    bqueue_destroy(&q);
+
+    printf("[test_scheduler] all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- introduce `test_scheduler.c` covering assignment, invalid data, resource shortages, and aging
- add new make target `test-scheduler` for running the integration test

## Testing
- `make -C progetti.3/lab2 test-utils test-parsers test-parse-env test-deadlock test-scheduler`

------
https://chatgpt.com/codex/tasks/task_e_686508762870832194cc86fe50275cc7