### PR TITLE
Add delay option to client

### DIFF
--- a/progetti.3/lab2/src/main.c
+++ b/progetti.3/lab2/src/main.c
@@ -1,5 +1,0 @@
-#include <stdio.h>
-int main() {
-    puts("Hello from lab2!");
-    return 0;
-}


### PR DESCRIPTION
## Summary
- allow specifying a delay before sending an emergency request
- adjust batch mode accordingly
- remove unused `main.c` that interfered with builds

## Testing
- `make -C progetti.3/lab2 client server`
- `make -C progetti.3/lab2 test-parsers`
- `make -C progetti.3/lab2 test-parse-env`
- `make -C progetti.3/lab2 test-deadlock`
- `make -C progetti.3/lab2 test-utils`
- `make -C progetti.3/lab2 test-scheduler`


------
https://chatgpt.com/codex/tasks/task_e_68650f09c5b88321ac70ef1693ff06a5