### PR TITLE
Introduce log_event_ex function

### DIFF
--- a/progetti.3/lab2/include/log.h
+++ b/progetti.3/lab2/include/log.h
@@ -11,6 +11,11 @@ int  log_init(const char *filepath);
  *  formato + argomenti variabili. Aggiunge data-ora e newline.  */
 void log_event(const char *fmt, ...);
 
+/*  Versione estesa: consente di specificare un identificatore e una
+ *  categoria dell'evento da registrare. L'output sarà del tipo:
+ *  [timestamp] [id] [event] messaggio                                 */
+void log_event_ex(const char *id, const char *event, const char *fmt, ...);
+
 /*  Chiudere il file prima di terminare il processo.             */
 void log_close(void);
 

--- a/progetti.3/lab2/src/digital_twin.c
+++ b/progetti.3/lab2/src/digital_twin.c
@@ -45,8 +45,11 @@ static void *twin_loop(void *arg)
         int eid = dt->emergency_id;
         dt->status = EN_ROUTE_TO_SCENE;
         scheduler_set_emergency_status(eid, EM_STATUS_IN_PROGRESS);
-        log_event("RESCUER_STATUS id=%d type=%s status=EN_ROUTE_TO_SCENE", dt->id, dt->type->name);
-        log_event("EMERGENCY_STATUS id=%d status=IN_PROGRESS", eid);
+        log_event_ex("DT", "RESCUER_STATUS",
+                    "id=%d type=%s status=EN_ROUTE_TO_SCENE",
+                    dt->id, dt->type->name);
+        log_event_ex("DT", "EMERGENCY_STATUS",
+                    "id=%d status=IN_PROGRESS", eid);
         pthread_mutex_unlock(&dt->mtx);
 
         double ttrav = travel_time_secs(dt->type, dt->x, dt->y, dx, dy);
@@ -59,7 +62,9 @@ static void *twin_loop(void *arg)
         pthread_mutex_lock(&dt->mtx);
         dt->x = dx; dt->y = dy;
         dt->status = ON_SCENE;
-        log_event("RESCUER_STATUS id=%d type=%s status=ON_SCENE", dt->id, dt->type->name);
+        log_event_ex("DT", "RESCUER_STATUS",
+                    "id=%d type=%s status=ON_SCENE",
+                    dt->id, dt->type->name);
         pthread_mutex_unlock(&dt->mtx);
 
         if (ts_sleep_intr(dt, mtime)) {
@@ -70,7 +75,9 @@ static void *twin_loop(void *arg)
 
         pthread_mutex_lock(&dt->mtx);
         dt->status = RETURNING_TO_BASE;
-        log_event("RESCUER_STATUS id=%d type=%s status=RETURNING_TO_BASE", dt->id, dt->type->name);
+        log_event_ex("DT", "RESCUER_STATUS",
+                    "id=%d type=%s status=RETURNING_TO_BASE",
+                    dt->id, dt->type->name);
         pthread_mutex_unlock(&dt->mtx);
 
         double tret = travel_time_secs(dt->type, dx, dy, dt->type->x, dt->type->y);
@@ -86,9 +93,12 @@ static void *twin_loop(void *arg)
         dt->status = IDLE;
         dt->assigned = 0;
         atomic_fetch_add(&dt->type->number, 1);
-        log_event("RESCUER_STATUS id=%d type=%s status=IDLE", dt->id, dt->type->name);
+        log_event_ex("DT", "RESCUER_STATUS",
+                    "id=%d type=%s status=IDLE",
+                    dt->id, dt->type->name);
         scheduler_set_emergency_status(eid, EM_STATUS_COMPLETED);
-        log_event("EMERGENCY_STATUS id=%d status=COMPLETED", eid);
+        log_event_ex("DT", "EMERGENCY_STATUS",
+                    "id=%d status=COMPLETED", eid);
         pthread_mutex_unlock(&dt->mtx);
     }
     pthread_mutex_unlock(&dt->mtx);

--- a/progetti.3/lab2/src/log.c
+++ b/progetti.3/lab2/src/log.c
@@ -21,10 +21,9 @@ void log_close(void)
     }
 }
 
-void log_event(const char *fmt, ...)
+static void log_event_v(const char *id, const char *event,
+                        const char *fmt, va_list ap)
 {
-    if (!fp) return;                      /* logger non inizializzato */
-
     time_t now = time(NULL);
     struct tm tm;
     localtime_r(&now, &tm);
@@ -34,15 +33,33 @@ void log_event(const char *fmt, ...)
 
     pthread_mutex_lock(&mtx);
 
-    fprintf(fp, "[%s] ", ts);
+    fprintf(fp, "[%s] [%s] [%s] ", ts,
+            id ? id : "", event ? event : "");
 
-    va_list ap;
-    va_start(ap, fmt);
     vfprintf(fp, fmt, ap);
-    va_end(ap);
 
     fputc('\n', fp);
     fflush(fp);          /* flush immediato: semplice e sicuro */
 
     pthread_mutex_unlock(&mtx);
+}
+
+void log_event_ex(const char *id, const char *event, const char *fmt, ...)
+{
+    if (!fp) return;                      /* logger non inizializzato */
+
+    va_list ap;
+    va_start(ap, fmt);
+    log_event_v(id, event, fmt, ap);
+    va_end(ap);
+}
+
+void log_event(const char *fmt, ...)
+{
+    if (!fp) return;                      /* logger non inizializzato */
+
+    va_list ap;
+    va_start(ap, fmt);
+    log_event_v("", "", fmt, ap);
+    va_end(ap);
 }

--- a/progetti.3/lab2/src/parse_emergency_types.c
+++ b/progetti.3/lab2/src/parse_emergency_types.c
@@ -59,7 +59,9 @@ int parse_emergency_types_file(const char *path,
             }
             int ridx = rescuer_index_by_name(rname, rlist, n_rlist);
             if (ridx < 0) {
-                log_event("FILE_PARSING: unknown rescuer type '%s' on line %d", rname, line_no);
+                log_event_ex("PARSE", "FILE_PARSING",
+                            "unknown rescuer type '%s' on line %d",
+                            rname, line_no);
                 valid_line = 0;
                 break;
             }

--- a/progetti.3/lab2/src/server.c
+++ b/progetti.3/lab2/src/server.c
@@ -86,22 +86,23 @@ int main(int argc, char *argv[]) {
         perror("log_init");
         return 1;
     }
-    log_event("Loaded %d rescuers, %d emergency types",
-              n_rescuers, n_etypes);
+    log_event_ex("SRV", "INFO",
+                "Loaded %d rescuers, %d emergency types",
+                n_rescuers, n_etypes);
 
     if (digital_twin_factory(rescuer_list, n_rescuers, &dt_list, &dt_count) != 0) {
-        log_event("Errore creazione digital twins");
+        log_event_ex("SRV", "ERROR", "Errore creazione digital twins");
         return 1;
     }
 
     /* 4) Queue interna + scheduler */
     bqueue_t queue;
     if (bqueue_init(&queue, 100) != 0) {
-        log_event("Errore init queue");
+        log_event_ex("SRV", "ERROR", "Errore init queue");
         return 1;
     }
     if (scheduler_start(&queue) != 0) {
-        log_event("Errore avvio scheduler");
+        log_event_ex("SRV", "ERROR", "Errore avvio scheduler");
         return 1;
     }
 
@@ -115,12 +116,12 @@ int main(int argc, char *argv[]) {
     };
     if (pthread_create(&listener_thread, NULL,
                        mq_listener, &args) != 0) {
-        log_event("pthread_create listener fallita");
+        log_event_ex("SRV", "ERROR", "pthread_create listener fallita");
         scheduler_stop();
         bqueue_destroy(&queue);
         return 1;
     }
-    log_event("Server avviato e in ascolto su %s", cfg.queue_name);
+    log_event_ex("SRV", "INFO", "Server avviato e in ascolto su %s", cfg.queue_name);
 
     /* 6) Attende CTRL-C */
     pthread_join(listener_thread, NULL);


### PR DESCRIPTION
## Summary
- extend `log.h` with `log_event_ex`
- include id and event in log output
- update all modules to use the new logging API

## Testing
- `make test-utils`
- `make test-parsers`
- `make test-parse-env`
- `make test-deadlock`
- `make test-scheduler`

------
https://chatgpt.com/codex/tasks/task_e_68653570ea7083218f68fb99dc6bb85e