### PR TITLE
Finalize build and thread management

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,20 @@ to change the POSIX queue name used by the server instead of the default
 `/emergenze123`.
 
 Runtime logs are stored in `logs/server.log`.
+
+## Build and test
+
+The `Makefile` under `progetti.3/lab2` provides convenient targets:
+
+```sh
+make -C progetti.3/lab2 server   # build the server binary
+make -C progetti.3/lab2 client   # build the client binary
+make -C progetti.3/lab2 test-utils      # run unit tests for utils
+make -C progetti.3/lab2 test-parsers    # run parser tests
+make -C progetti.3/lab2 test-parse-env  # run env parser tests
+make -C progetti.3/lab2 test-deadlock   # run deadlock monitor tests
+make -C progetti.3/lab2 test-scheduler  # run scheduler integration test
+```
+
+The default `make build` target builds the server, while `make run` launches it
+with the default configuration files.

--- a/progetti.3/lab2/Makefile
+++ b/progetti.3/lab2/Makefile
@@ -7,30 +7,18 @@ SRC_DIR := src
 OBJ_DIR := build
 BIN_DIR := bin
 
-# Main binary (lab2)
-BIN := $(BIN_DIR)/lab2
+# No monolithic binary is produced. Server and client are built separately.
 
-# Gather all .c under SRC_DIR
-SRCS := $(shell find $(SRC_DIR) -name '*.c')
-OBJS := $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SRCS))
 
 # --------------------------------------------------
 # Target principale: build / run / clean
 # --------------------------------------------------
 
 .PHONY: build run clean
-build: $(BIN)
+build: server
 
-$(BIN): $(OBJS)
-	@mkdir -p $(BIN_DIR)
-	$(CC) $(CFLAGS) $^ -o $@
-
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -Iinclude -c $< -o $@
-
-run: build
-	./$(BIN)
+run: server
+	./$(BIN_SERVER)
 
 clean:
 	rm -rf $(OBJ_DIR) $(BIN_DIR) logs/*.log tests/_*.txt

--- a/progetti.3/lab2/src/digital_twin.c
+++ b/progetti.3/lab2/src/digital_twin.c
@@ -125,7 +125,11 @@ int digital_twin_factory(rescuer_type_t *types, int n_types,
             dt->status = IDLE;
             pthread_mutex_init(&dt->mtx, NULL);
             pthread_cond_init(&dt->cond, NULL);
-            pthread_create(&dt->thread, NULL, twin_loop, dt);
+            if (pthread_create(&dt->thread, NULL, twin_loop, dt) != 0) {
+                log_event_ex("DT", "THREAD", "failed to start twin %d", id);
+                free(arr);
+                return -1;
+            }
             id++;
         }
     }


### PR DESCRIPTION
## Summary
- split client and server builds
- handle thread creation failures in digital twin module
- document build and test workflow

## Testing
- `make clean`
- `make server`
- `make client`
- `make test-utils`
- `make test-parsers`
- `make test-parse-env`
- `make test-deadlock`
- `make test-scheduler`

------
https://chatgpt.com/codex/tasks/task_e_686538e26b94832187c68a55b83d3165